### PR TITLE
Uploading as ipynb type

### DIFF
--- a/nb_anacondacloud/nbextension/uploader.py
+++ b/nb_anacondacloud/nbextension/uploader.py
@@ -42,7 +42,7 @@ class Uploader(object):
         try:
             return self.aserver_api.upload(self.username, self.project, self.version,
                                            self.name, self.content_io(),
-                                           re.sub('\-ipynb$', '', self.name))
+                                           "ipynb")
         except errors.Conflict:
             if force:
                 self.remove()


### PR DESCRIPTION
Fixes #3.

Unlike with the [upstream](https://github.com/Anaconda-Server/anaconda-client/blob/88aa0d0ca785093b716c8487470007642d50292b/binstar_client/utils/notebook/uploader.py#L41) there is no reason to even look at the file type, since we always know it will be an ipynb... 
