### PR TITLE
Fix to attach the current environment

### DIFF
--- a/nb_anacondacloud/uploader.py
+++ b/nb_anacondacloud/uploader.py
@@ -30,7 +30,11 @@ class Uploader(object):
         if self.metadata.get("attach-environment", None):
             self.env_name = self.metadata.get("environment", None)
             if self.env_name is None:
-                self.env_name = self.default_env()
+                ksname = self.ksname
+                # ksname comes in the form conda-env-name-py
+                # or conda-[root/default]-[py/r] and we need to get the name
+                # so split it and catch it.
+                self.env_name = ksname.split("-")[-2]
         else:
             self.env_name = None
 
@@ -168,6 +172,10 @@ class Uploader(object):
             return re.sub('\-ipynb$', '', self.name)
         else:
             return self._project
+
+    @property
+    def ksname(self):
+        return self.content.get("metadata", {}).get("kernelspec", {}).get("name", None)
 
     @property
     def metadata(self):

--- a/nb_anacondacloud/uploader.py
+++ b/nb_anacondacloud/uploader.py
@@ -175,7 +175,8 @@ class Uploader(object):
 
     @property
     def ksname(self):
-        return self.content.get("metadata", {}).get("kernelspec", {}).get("name", None)
+        ks = self.content.get("metadata", {}).get("kernelspec", {})
+        return ks.get("name", None)
 
     @property
     def metadata(self):

--- a/nb_anacondacloud/uploader.py
+++ b/nb_anacondacloud/uploader.py
@@ -31,10 +31,14 @@ class Uploader(object):
             self.env_name = self.metadata.get("environment", None)
             if self.env_name is None:
                 ksname = self.ksname
-                # ksname comes in the form conda-env-name-py
-                # or conda-[root/default]-[py/r] and we need to get the name
-                # so split it and catch it.
-                self.env_name = ksname.split("-")[-2]
+                if ksname in ["python2", "python3"]:
+                    # we are dealing with the native kernel, so let's find out
+                    # the name of the env where that kernel lives
+                    self.env_name = self.default_env()
+                else:
+                    # ksname comes in the form conda-env-name-[py/r] or
+                    # conda-root-[py/r] so split them and catch the name
+                    self.env_name = ksname.split("-")[-2]
         else:
             self.env_name = None
 


### PR DESCRIPTION
We should attach the env we are currently running on, not the default one.
So, we get the env name from the kernelspec and we use that to actually get the proper conda list for that environment.