### PR TITLE
Add declaration yaml file for jupyter_nbextensions_configurator

### DIFF
--- a/nb_anacondacloud/static/jupyter_nbextensions_configurator.yaml
+++ b/nb_anacondacloud/static/jupyter_nbextensions_configurator.yaml
@@ -1,0 +1,12 @@
+# This file declares this nbextension to the jupyter_nbextensions_configurator.
+# See
+#     https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator
+# for further details.
+Type: Jupyter Notebook Extension
+Name: Anaconda Cloud
+Description: |
+  Interact with Anaconda Cloud from the notebook.
+  Adds a toolbar button to upload notebooks to Anaconda Cloud.
+Main: main.js
+Compatibility: 4.x
+Link: https://github.com/Anaconda-Platform/nb_anacondacloud


### PR DESCRIPTION
Fixes #37. It is common for the configurator to include a small markdown readme in the static files, which can be rendered by the configurator, but there isn't one in the repo, so I've just added a link to the repo (which will show the main readme) for now.
