### PR TITLE
WIP Fix travis

### DIFF
--- a/nb_anacondacloud/static/main.js
+++ b/nb_anacondacloud/static/main.js
@@ -1,6 +1,8 @@
-define(['jquery', 'base/js/dialog', 'base/js/namespace'],
-function ($, dialog, Jupyter) {
+define(['jquery', 'base/js/dialog', 'base/js/namespace', 'base/js/utils'],
+function ($, dialog, Jupyter, utils) {
     'use strict';
+
+    var ajax = utils.ajax || $.ajax;
 
     var NS = 'anaconda-cloud',
       THUMBNAIL_MIN_DIM = 48,
@@ -58,7 +60,7 @@ function ($, dialog, Jupyter) {
     function uploadNotebook() {
         var interval;
 
-        $.ajax({
+        ajax({
               url: api('publish'),
               method: 'POST',
               dataType: 'json',
@@ -149,7 +151,7 @@ function ($, dialog, Jupyter) {
         Jupyter.notification_area.get_widget('notebook')
             .set_message('Connecting to Anaconda Cloud', 2000);
 
-        $.ajax({
+        ajax({
             url: api('login'),
             method: 'GET',
             dataType: 'json',
@@ -498,7 +500,7 @@ function ($, dialog, Jupyter) {
     }
 
     function loginIntoAnaconda() {
-        $.ajax({
+        ajax({
             url: api('login'),
             method: 'POST',
             dataType: 'json',

--- a/nb_anacondacloud/static/main.js
+++ b/nb_anacondacloud/static/main.js
@@ -60,8 +60,7 @@ function ($, dialog, Jupyter, utils) {
     function uploadNotebook() {
         var interval;
 
-        ajax({
-              url: api('publish'),
+        ajax(api('publish'), {
               method: 'POST',
               dataType: 'json',
               contentType: 'application/json; charset=utf-8',
@@ -151,8 +150,7 @@ function ($, dialog, Jupyter, utils) {
         Jupyter.notification_area.get_widget('notebook')
             .set_message('Connecting to Anaconda Cloud', 2000);
 
-        ajax({
-            url: api('login'),
+        ajax(api('login'), {
             method: 'GET',
             dataType: 'json',
             contentType: 'application/json; charset=utf-8',
@@ -500,8 +498,7 @@ function ($, dialog, Jupyter, utils) {
     }
 
     function loginIntoAnaconda() {
-        ajax({
-            url: api('login'),
+        ajax(api('login'), {
             method: 'POST',
             dataType: 'json',
             contentType: 'application/json; charset=utf-8',

--- a/nb_anacondacloud/tests/test_notebook.py
+++ b/nb_anacondacloud/tests/test_notebook.py
@@ -95,6 +95,7 @@ class NBAnacondaCloudTestController(jstest.JSController):
     # copy pasta from...
     # https://github.com/jupyter/notebook/blob/master/notebook/jstest.py#L234
     def setup(self):
+        self.empty = ''
         self.ipydir = jstest.TemporaryDirectory()
         self.config_dir = jstest.TemporaryDirectory()
         self.nbdir = jstest.TemporaryDirectory()
@@ -147,6 +148,8 @@ class NBAnacondaCloudTestController(jstest.JSController):
             '--no-browser',
             '--notebook-dir', self.nbdir.name,
             '--NotebookApp.base_url=%s' % self.base_url,
+            '--NotebookApp.token=%s' % self.empty,
+            '--NotebookApp.password=%s' % self.empty,
         ]
 
         # ipc doesn't work on Windows, and darwin has crazy-long temp paths,


### PR DESCRIPTION
Still not working, in the repo, in this specific branch (fix_travis) you can do:
```
conda create -n test python=3.6 notebook
source activate test
```
then
```
conda install -c conda-forge nb_conda_kernels
conda install --file requirements.txt
npm install
pip install -e .
jupyter nbextension install nb_anacondacloud --py --sys-prefix
jupyter nbextension enable nb_anacondacloud --py --sys-prefix
jupyter serverextension enable nb_anacondacloud --py --sys-prefix
```
then
```
jupyter notebook
```
and try using the nb_anacondacloud extensions triggers:
```
[W 07:00:58.436 NotebookApp] 403 POST /anaconda-cloud/publish (127.0.0.1): '_xsrf' argument missing from POST
[W 07:00:58.440 NotebookApp] 403 POST /anaconda-cloud/publish (127.0.0.1) 5.25ms referer=http://localhost:8888/notebooks/Untitled.ipynb
```

@minrk, can you try to reproduce? I am pretty sure I don't have stale js around...